### PR TITLE
Add custom_fields_group_tag to user preference

### DIFF
--- a/app/views/issues/_form_custom_fields.html.erb
+++ b/app/views/issues/_form_custom_fields.html.erb
@@ -3,7 +3,7 @@
   <% if values.present? %>
     <% full_width_values = values.select { |value| value.custom_field.full_width_layout? } %>
     <% half_width_values = values - full_width_values %>
-    <% if custom_fields_group_tag == 'fieldset+legend' %>
+    <% if custom_fields_group_tag == 'fieldset' %>
       <% if title.nil? %>
         <% if half_width_values.present? %>
           <div class="splitcontent">

--- a/app/views/issues/_form_custom_fields.html.erb
+++ b/app/views/issues/_form_custom_fields.html.erb
@@ -1,9 +1,9 @@
-<% group_tag = Setting.plugin_redmine_custom_fields_groups['group_tag'] || 'h4' %>
+<% custom_fields_group_tag = Setting.plugin_redmine_custom_fields_groups['custom_fields_group_tag'] || 'h4' %>
 <% grouped_custom_field_values(@issue.editable_custom_field_values).each do |title, values| %>
   <% if values.present? %>
     <% full_width_values = values.select { |value| value.custom_field.full_width_layout? } %>
     <% half_width_values = values - full_width_values %>
-    <% if group_tag == 'fieldset+legend' %>
+    <% if custom_fields_group_tag == 'fieldset+legend' %>
       <% if title.nil? %>
         <% if half_width_values.present? %>
           <div class="splitcontent">
@@ -51,7 +51,7 @@
         </fieldset>
       <% end %>
     <% else %>
-      <%= content_tag(group_tag, title, :class => "custom-fields-groups") unless title.nil? %>
+      <%= content_tag(custom_fields_group_tag, title, :class => "custom-fields-groups") unless title.nil? %>
       <% if half_width_values.present? %>
         <div class="splitcontent">
           <div class="splitcontentleft">

--- a/app/views/issues/_form_custom_fields.html.erb
+++ b/app/views/issues/_form_custom_fields.html.erb
@@ -1,4 +1,12 @@
-<% custom_fields_group_tag = Setting.plugin_redmine_custom_fields_groups['custom_fields_group_tag'] || 'h4' %>
+<% custom_fields_group_tag = User.current.pref.custom_fields_group_tag %>
+<% if custom_fields_group_tag.blank? %>
+  <% custom_fields_group_tag = Setting.plugin_redmine_custom_fields_groups['custom_fields_group_tag'] || 'h4' %>
+<% end %>
+<% fieldset_default_state = User.current.pref.fieldset_default_state %>
+<% if fieldset_default_state.blank? %>
+  <% fieldset_default_state = Setting.plugin_redmine_custom_fields_groups['fieldset_default_state'] || 'all_expended' %>
+<% end %>
+<% all_collapsed = (fieldset_default_state == 'all_collapsed') %>
 <% grouped_custom_field_values(@issue.editable_custom_field_values).each do |title, values| %>
   <% if values.present? %>
     <% full_width_values = values.select { |value| value.custom_field.full_width_layout? } %>
@@ -26,10 +34,13 @@
           <%= wikitoolbar_for "issue_custom_field_values_#{value.custom_field_id}", preview_issue_path(:project_id => @issue.project, :issue_id => @issue.id) if value.custom_field.full_text_formatting? %>
         <% end %>
       <% else %>
-        <fieldset class="collapsible custom-fields-groups">
-          <%= content_tag('legend', title, :onclick => "toggleFieldset(this);", :class => "icon icon-expended") %>
+        <% fieldset_class = 'collapsible custom-fields-groups' + (all_collapsed ? ' collapsed' : '') %>
+        <% legend_class = 'icon ' + (all_collapsed ? 'icon-collapsed' : 'icon-expended') %>
+        <% div_style = all_collapsed ? 'display: none' : '' %>
+        <fieldset class="<%= fieldset_class %>">
+          <%= content_tag('legend', title, :onclick => "toggleFieldset(this);", :class => legend_class) %>
           <% if half_width_values.present? %>
-            <div class="splitcontent">
+            <div class="splitcontent" style="<%= div_style %>">
               <div class="splitcontentleft">
                 <% i = 0 %>
                 <% split_on = (half_width_values.size / 2.0).ceil - 1 %>
@@ -45,7 +56,7 @@
             </div>
           <% end %>
           <% full_width_values.each do |value| %>
-            <p><%= custom_field_tag_with_label :issue, value, :required => @issue.required_attribute?(value.custom_field_id) %></p>
+            <div style="<%= div_style %>"><p><%= custom_field_tag_with_label :issue, value, :required => @issue.required_attribute?(value.custom_field_id) %></p></div>
             <%= wikitoolbar_for "issue_custom_field_values_#{value.custom_field_id}", preview_issue_path(:project_id => @issue.project, :issue_id => @issue.id) if value.custom_field.full_text_formatting? %>
           <% end %>
         </fieldset>

--- a/app/views/settings/_redmine_custom_fields_groups.html.erb
+++ b/app/views/settings/_redmine_custom_fields_groups.html.erb
@@ -2,11 +2,11 @@
   <h3><%= l(:label_custom_fields_group_settings) %></h3>
   <p>
     <%= content_tag(:label, l(:label_custom_fields_group_tag)) %>
-    <%= select_tag('settings[group_tag]',
+    <%= select_tag('settings[custom_fields_group_tag]',
                    options_for_select([
                      ["h3", "h3"],
                      ["h4", "h4"],
                      ["fieldset+legend", "fieldset+legend"]
-                   ], @settings['group_tag'].to_s)) %>
+                   ], @settings['custom_fields_group_tag'].to_s)) %>
   </p>
 </div>

--- a/app/views/settings/_redmine_custom_fields_groups.html.erb
+++ b/app/views/settings/_redmine_custom_fields_groups.html.erb
@@ -3,10 +3,15 @@
   <p>
     <%= content_tag(:label, l(:label_custom_fields_group_tag)) %>
     <%= select_tag('settings[custom_fields_group_tag]',
-                   options_for_select([
-                     ["h3", "h3"],
-                     ["h4", "h4"],
-                     ["fieldset+legend", "fieldset+legend"]
-                   ], @settings['custom_fields_group_tag'].to_s)) %>
+                    options_for_select(
+                      RedmineCustomFieldsGroups::Options::GROUP_TAGS,
+                      @settings['custom_fields_group_tag'].to_s)) %>
+  </p>
+  <p>
+    <%= content_tag(:label, l(:label_fieldset_default_state)) %>
+    <%= select_tag('settings[fieldset_default_state]',
+                    options_for_select(
+                      RedmineCustomFieldsGroups::Options::FIELDSET_STATES,
+                      @settings['fieldset_default_state'].to_s)) %>
   </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,9 @@ en:
   label_custom_fields_group_plural: Custom Fields Groups
   label_custom_fields_group_settings: Custom Fields Group Settings
   label_custom_fields_group_tag: Custom Fields Group Tag
+  label_group_tag_h3: H3
+  label_group_tag_h4: H4
+  label_group_tag_fieldset: Fieldset
+  label_fieldset_default_state: Fieldset Default State
+  label_fieldset_state_all_expended: All expended
+  label_fieldset_state_all_collapsed: All collapsed

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,3 +5,9 @@ ja:
   label_custom_fields_group_plural: カスタムフィールドグループ
   label_custom_fields_group_settings: カスタムフィールドグループ設定
   label_custom_fields_group_tag: カスタムフィールドグループタグ
+  label_group_tag_h3: H3
+  label_group_tag_h4: H4
+  label_group_tag_fieldset: フィールドセット
+  label_fieldset_default_state: フィールドセットのデフォルト状態
+  label_fieldset_state_all_expended: 全て展開
+  label_fieldset_state_all_collapsed: 全て折りたたみ

--- a/init.rb
+++ b/init.rb
@@ -12,7 +12,7 @@ Redmine::Plugin.register :redmine_custom_fields_groups do
 
   settings partial: 'settings/redmine_custom_fields_groups',
     default: {
-      'group_tag' => 'h4',
+      'custom_fields_group_tag' => 'h4',
     }
 
   menu :admin_menu,

--- a/init.rb
+++ b/init.rb
@@ -13,6 +13,7 @@ Redmine::Plugin.register :redmine_custom_fields_groups do
   settings partial: 'settings/redmine_custom_fields_groups',
     default: {
       'custom_fields_group_tag' => 'h4',
+      'fieldset_default_state' => 'all_expended'
     }
 
   menu :admin_menu,

--- a/lib/redmine_custom_fields_groups.rb
+++ b/lib/redmine_custom_fields_groups.rb
@@ -3,7 +3,9 @@ Rails.application.paths["app/overrides"] << File.expand_path("../../app/override
 
 Rails.configuration.to_prepare do
   require 'redmine_custom_fields_groups/hooks/view_layouts_base_html_head_hook'
+  require 'redmine_custom_fields_groups/hooks/view_user_preferences_hook'
   require 'redmine_custom_fields_groups/patches/issues_helper_patch'
+  require 'redmine_custom_fields_groups/patches/user_preference_patch'
 end
 
 module RedmineCustomFieldsGroups

--- a/lib/redmine_custom_fields_groups/hooks/view_user_preferences_hook.rb
+++ b/lib/redmine_custom_fields_groups/hooks/view_user_preferences_hook.rb
@@ -1,0 +1,38 @@
+module RedmineCustomFieldsGroups
+  module Hooks
+    class ViewUserPreferencesHook < Redmine::Hook::ViewListener
+      def view_users_form_preferences(context={})
+        user_custom_fields_group_options(context)
+      end
+
+      def view_my_account_preferences(context={})
+        user_custom_fields_group_options(context)
+      end
+
+      def user_custom_fields_group_options(context)
+        user  = context[:user]
+        f     = context[:form]
+        s     = ''
+
+        s << "<p>"
+        s << label_tag("pref_custom_fields_group_tag", l(:label_custom_fields_group_tag))
+        s << select_tag(
+                "pref[custom_fields_group_tag]",
+                options_for_select(RedmineCustomFieldsGroups::Options::GROUP_TAGS, user.pref.custom_fields_group_tag),
+                :id => 'pref_custom_fields_group_tag'
+              )
+        s << "</p>"
+        s << "<p>"
+        s << label_tag("pref_fieldset_default_state", l(:label_fieldset_default_state))
+        s << select_tag(
+                "pref[fieldset_default_state]",
+                options_for_select(RedmineCustomFieldsGroups::Options::FIELDSET_STATES, user.pref.fieldset_default_state),
+                :id => 'pref_fieldset_default_state'
+              )
+        s << "</p>"
+
+        return s.html_safe
+      end
+    end
+  end
+end

--- a/lib/redmine_custom_fields_groups/hooks/view_user_preferences_hook.rb
+++ b/lib/redmine_custom_fields_groups/hooks/view_user_preferences_hook.rb
@@ -18,16 +18,18 @@ module RedmineCustomFieldsGroups
         s << label_tag("pref_custom_fields_group_tag", l(:label_custom_fields_group_tag))
         s << select_tag(
                 "pref[custom_fields_group_tag]",
-                options_for_select(RedmineCustomFieldsGroups::Options::GROUP_TAGS, user.pref.custom_fields_group_tag),
-                :id => 'pref_custom_fields_group_tag'
+                options_for_select([["",""]] + RedmineCustomFieldsGroups::Options::GROUP_TAGS, user.pref.custom_fields_group_tag),
+                :id => 'pref_custom_fields_group_tag',
+                :blank => ''
               )
         s << "</p>"
         s << "<p>"
         s << label_tag("pref_fieldset_default_state", l(:label_fieldset_default_state))
         s << select_tag(
                 "pref[fieldset_default_state]",
-                options_for_select(RedmineCustomFieldsGroups::Options::FIELDSET_STATES, user.pref.fieldset_default_state),
-                :id => 'pref_fieldset_default_state'
+                options_for_select([["",""]] + RedmineCustomFieldsGroups::Options::FIELDSET_STATES, user.pref.fieldset_default_state),
+                :id => 'pref_fieldset_default_state',
+                :blank => ''
               )
         s << "</p>"
 

--- a/lib/redmine_custom_fields_groups/options.rb
+++ b/lib/redmine_custom_fields_groups/options.rb
@@ -1,0 +1,14 @@
+module RedmineCustomFieldsGroups
+  class Options
+    include Redmine::I18n
+    GROUP_TAGS = [
+      [l(:label_group_tag_h3), "h3"],
+      [l(:label_group_tag_h4), "h4"],
+      [l(:label_group_tag_fieldset), "fieldset"]
+    ]
+    FIELDSET_STATES = [
+      [l(:label_fieldset_state_all_expended), "all_expended"],
+      [l(:label_fieldset_state_all_collapsed), "all_collapsed"],
+    ]
+  end
+end

--- a/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
+++ b/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
@@ -27,7 +27,15 @@ module RedmineCustomFieldsGroups
             custom_field_values = issue.visible_custom_field_values
             return if custom_field_values.empty?
 
-            custom_fields_group_tag = Setting.plugin_redmine_custom_fields_groups['custom_fields_group_tag'] || 'h4'
+            custom_fields_group_tag = User.current.pref.custom_fields_group_tag
+            if custom_fields_group_tag.blank?
+              custom_fields_group_tag = Setting.plugin_redmine_custom_fields_groups['custom_fields_group_tag'] || 'h4'
+            end
+            fieldset_default_state = User.current.pref.fieldset_default_state
+            if fieldset_default_state.blank?
+              fieldset_default_state = Setting.plugin_redmine_custom_fields_groups['fieldset_default_state'] || 'all_expended'
+            end
+
             s = ''.html_safe
             grouped_custom_field_values(custom_field_values).each do |title, values|
               if values.present?
@@ -49,6 +57,10 @@ module RedmineCustomFieldsGroups
                   s << render_full_width_custom_fields_rows_by_grouped_values(issue, values)
                 end
               end
+            end
+            # temporary hack
+            if custom_fields_group_tag == 'fieldset' && fieldset_default_state == 'all_collapsed'
+              s << javascript_tag("$('div.issue div.attributes fieldset.custom-fields-groups>legend').each(function(idx,elem){toggleFieldset(elem);})")
             end
             s
           end

--- a/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
+++ b/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
@@ -27,11 +27,11 @@ module RedmineCustomFieldsGroups
             custom_field_values = issue.visible_custom_field_values
             return if custom_field_values.empty?
 
-            group_tag = Setting.plugin_redmine_custom_fields_groups['group_tag'] || 'h4'
+            custom_fields_group_tag = Setting.plugin_redmine_custom_fields_groups['custom_fields_group_tag'] || 'h4'
             s = ''.html_safe
             grouped_custom_field_values(custom_field_values).each do |title, values|
               if values.present?
-                if group_tag == 'fieldset+legend'
+                if custom_fields_group_tag == 'fieldset+legend'
                   if title.nil?
                     s << render_half_width_custom_fields_rows_by_grouped_values(issue, values)
                     s << render_full_width_custom_fields_rows_by_grouped_values(issue, values)
@@ -44,7 +44,7 @@ module RedmineCustomFieldsGroups
                     end
                   end
                 else
-                  s << content_tag(group_tag, title, :class => 'custom-fields-groups') unless title.nil?
+                  s << content_tag(custom_fields_group_tag, title, :class => 'custom-fields-groups') unless title.nil?
                   s << render_half_width_custom_fields_rows_by_grouped_values(issue, values)
                   s << render_full_width_custom_fields_rows_by_grouped_values(issue, values)
                 end

--- a/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
+++ b/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
@@ -31,7 +31,7 @@ module RedmineCustomFieldsGroups
             s = ''.html_safe
             grouped_custom_field_values(custom_field_values).each do |title, values|
               if values.present?
-                if custom_fields_group_tag == 'fieldset+legend'
+                if custom_fields_group_tag == 'fieldset'
                   if title.nil?
                     s << render_half_width_custom_fields_rows_by_grouped_values(issue, values)
                     s << render_full_width_custom_fields_rows_by_grouped_values(issue, values)

--- a/lib/redmine_custom_fields_groups/patches/user_preference_patch.rb
+++ b/lib/redmine_custom_fields_groups/patches/user_preference_patch.rb
@@ -1,0 +1,36 @@
+module RedmineCustomFieldsGroups
+  module Patches
+    module UserPreferencePatch
+
+      def self.included(base) # :nodoc:
+        base.send(:include, InstanceMethods)
+
+        base.class_eval do
+          safe_attributes 'custom_fields_group_tag', 'fieldset_default_state'
+        end
+      end
+
+      module InstanceMethods
+        def custom_fields_group_tag
+          self[:custom_fields_group_tag]
+        end
+
+        def custom_fields_group_tag=(new_value)
+          self[:custom_fields_group_tag] = new_value
+        end
+
+        def fieldset_default_state
+          self[:fieldset_default_state]
+        end
+
+        def fieldset_default_state=(new_value)
+          self[:fieldset_default_state] = new_value
+        end
+      end
+    end
+  end
+end
+
+unless UserPreference.included_modules.include?(RedmineCustomFieldsGroups::Patches::UserPreferencePatch)
+  UserPreference.send(:include, RedmineCustomFieldsGroups::Patches::UserPreferencePatch)
+end


### PR DESCRIPTION
Supports #1.

Changes proposed in this pull request:
- Renamed `group_tag` to `custom_fields_group_tag`
- Adding user preferences with some break changes
- .etc

@gtt-project/maintainer
