### PR TITLE
Supported automatic code reloading

### DIFF
--- a/lib/redmine_custom_fields_groups.rb
+++ b/lib/redmine_custom_fields_groups.rb
@@ -2,11 +2,12 @@ Rails.application.paths["app/overrides"] ||= []
 Rails.application.paths["app/overrides"] << File.expand_path("../../app/overrides", __FILE__)
 
 Rails.configuration.to_prepare do
-  require 'redmine_custom_fields_groups/hooks/view_layouts_base_html_head_hook'
-  require 'redmine_custom_fields_groups/hooks/view_user_preferences_hook'
-  require 'redmine_custom_fields_groups/patches/issues_helper_patch'
-  require 'redmine_custom_fields_groups/patches/user_preference_patch'
+  IssuesHelper.send(:include, RedmineCustomFieldsGroups::Patches::IssuesHelperPatch)
+  UserPreference.send(:include, RedmineCustomFieldsGroups::Patches::UserPreferencePatch)
 end
+
+require 'redmine_custom_fields_groups/hooks/view_layouts_base_html_head_hook'
+require 'redmine_custom_fields_groups/hooks/view_user_preferences_hook'
 
 module RedmineCustomFieldsGroups
 end

--- a/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
+++ b/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
@@ -112,7 +112,3 @@ module RedmineCustomFieldsGroups
     end #module
   end #module
 end #module
-
-unless IssuesHelper.included_modules.include?(RedmineCustomFieldsGroups::Patches::IssuesHelperPatch)
-  IssuesHelper.send(:include, RedmineCustomFieldsGroups::Patches::IssuesHelperPatch)
-end

--- a/lib/redmine_custom_fields_groups/patches/user_preference_patch.rb
+++ b/lib/redmine_custom_fields_groups/patches/user_preference_patch.rb
@@ -30,7 +30,3 @@ module RedmineCustomFieldsGroups
     end
   end
 end
-
-unless UserPreference.included_modules.include?(RedmineCustomFieldsGroups::Patches::UserPreferencePatch)
-  UserPreference.send(:include, RedmineCustomFieldsGroups::Patches::UserPreferencePatch)
-end


### PR DESCRIPTION
Fixes #9.

Changes proposed in this pull request:
- Supported automatic code reloading
  - Moved each patches last `XXX.send(:include, YYY)` lines without `unless` check
  - Moved hooks to global space

@gtt-project/maintainer
