### PR TITLE
Fixed migrate error on mysql

### DIFF
--- a/db/migrate/20211011081244_create_custom_fields_group_fields.rb
+++ b/db/migrate/20211011081244_create_custom_fields_group_fields.rb
@@ -2,7 +2,7 @@ class CreateCustomFieldsGroupFields < ActiveRecord::Migration[5.2]
   def change
     create_table :custom_fields_group_fields, id: false do |t|
       t.references :custom_fields_group, index: true, foreign_key: true
-      t.references :custom_field, index: { unique: true }, foreign_key: true
+      t.references :custom_field, index: { unique: true }, foreign_key: true, type: :integer
 
       # t.timestamps null: false
     end


### PR DESCRIPTION
Fixes #19.

Changes proposed in this pull request:
- Fixed migrate error on mysql

Related links:
- [【Rails】モデルに外部キーを設定する方法とよく起こるエラー内容について - AUTOVICE](https://autovice.jp/articles/176)

@gtt-project/maintainer
