### PR TITLE
Use GitHub Actions Marketplace "Setup Redmine" for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,6 @@ jobs:
     name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} db:${{ matrix.db }}
     runs-on: ubuntu-22.04
 
-    container:
-      image: ruby:${{ matrix.ruby_version }}-bullseye
-
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           - system_test: true
             redmine_version: 5.1-stable
             ruby_version: '3.2'
-            db: mysql
+            db: 'mysql:5.7'
         exclude:
           - redmine_version: 4.2-stable
             ruby_version: '3.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,18 @@ jobs:
         with:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
 
+      - name: Install Ruby dependencies
+        working-directory: redmine
+        run: |
+          bundle config set --local without 'development'
+          bundle install --jobs=4 --retry=3
+
+      - name: Run Redmine rake tasks
+        working-directory: redmine
+        run: |
+          bundle exec rake generate_secret_token
+          bundle exec rake db:create db:migrate redmine:plugins:migrate
+
       - name: Zeitwerk check
         working-directory: redmine
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         redmine_version: [4.2-stable, 5.0-stable, 5.1-stable, master]
         ruby_version: ['2.7', '3.0', '3.1', '3.2']
-        db: [mysql, postgres, sqlite]
+        db: [mysql:5.7, postgres:10, sqlite3]
         # System test takes 2~3 times longer, so limit to specific matrix combinations
         # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
@@ -47,31 +47,14 @@ jobs:
           - redmine_version: master
             ruby_version: '2.7'
 
-    services:
-      mysql:
-        image: mysql:5.7 # min
-        # image: mysql:8.0 # latest
-        env:
-          MYSQL_ROOT_PASSWORD: password
-        ports:
-          - 3306:3306
-        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
-      postgres:
-        image: postgres:10 # min
-        # image: postgres:15 # latest
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
-      - name: Checkout Redmine
-        uses: actions/checkout@v4
+      - name: Setup Redmine
+        uses: hidakatsuya/action-setup-redmine@v1
         with:
           repository: redmine/redmine
-          ref: ${{ matrix.redmine_version }}
+          version: ${{ matrix.redmine_version }}
+          ruby-version: ${{ matrix.ruby_version }}
+          database: ${{ matrix.db }}
           path: redmine
 
       - name: Checkout Plugin
@@ -79,80 +62,7 @@ jobs:
         with:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
 
-      - name: Update package archives
-        run: apt-get update --yes --quiet
-
-      - name: Install package dependencies
-        run: |
-          if [ ${{ matrix.db }} = "mysql" ]; then
-            apt-get install --yes --quiet default-mysql-client-core
-          fi
-          if [ ${{ matrix.db }} = "postgres" ]; then
-            apt-get install --yes --quiet postgresql-client
-          fi
-          # For system test
-          if [ ${{ matrix.system_test }} = "true" ]; then
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-            sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-            apt-get -y update
-            apt-get install -y google-chrome-stable
-          fi
-
-      - name: Verify MySQL connection from host
-        if: matrix.db == 'mysql'
-        run: |
-          mysql --host mysql --port 3306 -uroot -ppassword -e "SHOW DATABASES"
-
-      - name: Prepare Redmine source
-        working-directory: redmine
-        run: |
-          if [ ${{ matrix.db }} = "mysql" ]; then
-            cat <<EOF > config/database.yml
-              test:
-                adapter: mysql2
-                database: redmine
-                host: mysql
-                username: root
-                password: password
-                encoding: utf8mb4
-          EOF
-          fi
-          if [ ${{ matrix.db }} = "postgres" ]; then
-            cat <<EOF > config/database.yml
-              test:
-                adapter: postgresql
-                database: redmine
-                host: postgres
-                username: postgres
-                password: postgres
-                encoding: utf8
-          EOF
-          fi
-          if [ ${{ matrix.db }} = "sqlite" ]; then
-            cat <<EOF > config/database.yml
-              test:
-                adapter: sqlite3
-                database: db/redmine.sqlite3
-          EOF
-          fi
-
-      - name: Install Ruby dependencies
-        working-directory: redmine
-        run: |
-          bundle config set --local without 'development'
-          bundle install --jobs=4 --retry=3
-
-      - name: Run Redmine rake tasks
-        env:
-          RAILS_ENV: test
-        working-directory: redmine
-        run: |
-          bundle exec rake generate_secret_token
-          bundle exec rake db:create db:migrate redmine:plugins:migrate
-
       - name: Zeitwerk check
-        env:
-          RAILS_ENV: test
         working-directory: redmine
         run: |
           if grep -q zeitwerk config/application.rb ; then
@@ -161,10 +71,6 @@ jobs:
         shell: bash
 
       - name: Run plugin tests
-        env:
-          RAILS_ENV: test
-          # For system test in plugin
-          GOOGLE_CHROME_OPTS_ARGS: "headless,disable-gpu,no-sandbox,disable-dev-shm-usage"
         working-directory: redmine
         run: |
           bundle exec rake redmine:plugins:test:units NAME=${{ env.PLUGIN_NAME }} RUBYOPT="-W0"
@@ -190,7 +96,5 @@ jobs:
       #   run: bundle exec rake test:system
 
       - name: Run uninstall test
-        env:
-          RAILS_ENV: test
         working-directory: redmine
         run: bundle exec rake redmine:plugins:migrate NAME=${{ env.PLUGIN_NAME }} VERSION=0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         redmine_version: [4.2-stable, 5.0-stable, 5.1-stable, master]
         ruby_version: ['2.7', '3.0', '3.1', '3.2']
-        db: [mysql:5.7, postgres:10, sqlite3]
+        db: ['mysql:5.7', 'postgres:10', 'sqlite3']
         # System test takes 2~3 times longer, so limit to specific matrix combinations
         # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:


### PR DESCRIPTION
Changes proposed in this pull request:
- Use GitHub Actions Marketplace [Setup Redmine](https://github.com/marketplace/actions/setup-redmine) for CI

@dkastl @smellman @mopinfish
I replaced CI from my original implementation to use above [Setup Redmine](https://github.com/marketplace/actions/setup-redmine) (`hidakatsuya/action-setup-redmine@v1`).

The action's good points are followings:
* Create PostgreSQL/MySQL instance inside the action (not as `services` ([link](https://github.com/gtt-project/redmine_custom_fields_groups/blob/09f35b50766de844d22ca3ac1b7dc45d58b060eb/.github/workflows/test.yml#L50-L67)) which can't be controlled by matrix db type).
* Generating `config/database.yml` process is encapsulated in the action's [action.yml](https://github.com/hidakatsuya/action-setup-redmine/blob/main/action.yml).
* Environment variables (`RAILS_ENV=test` and `GOOGLE_CHROME_OPTS_ARGS=...`) are set globally in action side.

As a result, `.github/workflows/test.yml` code lines decrease to about half (196 => 109) and there was no explicit performance down.
* Total duration:
  * Before: 4m 1s ([link](https://github.com/gtt-project/redmine_custom_fields_groups/actions/runs/9337858111))
  * After: 4m 9s ([link](https://github.com/gtt-project/redmine_custom_fields_groups/actions/runs/9342582568))

If there are no objections, I am thinking to use the action in other plugins' CI,
so checking this PR is helpful. 🙇