### PR TITLE
Typo "expended" changed to "expanded"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,23 +22,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: [5.0-stable, 5.1-stable, 6.0-stable, master]
+        redmine_version: [5.1-stable, 6.0-stable, master]
         ruby_version: ['3.1', '3.2', '3.3']
-        db: ['mysql:5.7', 'postgres:10', 'sqlite3']
+        db: ['mysql:8.0', 'postgres:14', 'sqlite3']
         # System test takes 2~3 times longer, so limit to specific matrix combinations
         # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
           - system_test: true
             redmine_version: 6.0-stable
             ruby_version: '3.3'
-            db: 'mysql:5.7'
+            db: 'mysql:8.0'
         exclude:
-          - redmine_version: 5.0-stable
-            ruby_version: '3.2'
-          - redmine_version: 5.0-stable
-            ruby_version: '3.3'
           - redmine_version: 5.1-stable
             ruby_version: '3.3'
+          - redmine_version: master
+            ruby_version: '3.1'
 
     steps:
       - name: Setup Redmine

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a plugin for grouping custom fields.
 
 ## Requirements
 
-- Redmine >= 4.0.0
+- Redmine >= 5.1.0
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Redmine Custom Fields Groups Plugin
 
+[![CI](https://github.com/gtt-project/redmine_custom_fields_groups/actions/workflows/test.yml/badge.svg)](https://github.com/gtt-project/redmine_custom_fields_groups/actions?query=workflow%3ATest+branch%3Amain)
+
 This is a plugin for grouping custom fields.
 
 ## Requirements

--- a/app/views/issues/_form_custom_fields.html.erb
+++ b/app/views/issues/_form_custom_fields.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 <% fieldset_default_state = User.current.pref.fieldset_default_state %>
 <% if fieldset_default_state.blank? %>
-  <% fieldset_default_state = Setting.plugin_redmine_custom_fields_groups['fieldset_default_state'] || 'all_expended' %>
+  <% fieldset_default_state = Setting.plugin_redmine_custom_fields_groups['fieldset_default_state'] || 'all_expanded' %>
 <% end %>
 <% all_collapsed = (fieldset_default_state == 'all_collapsed') %>
 <% grouped_custom_field_values(@issue.editable_custom_field_values).each do |title, values| %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -13,4 +13,4 @@ de:
   label_group_tag_fieldset: Eingabefeld
   label_fieldset_default_state: Grundeinstellung für Eingabefeld
   label_fieldset_state_all_collapsed: Alle zusammengeklappt
-  label_fieldset_state_all_expended: Alle erweitert
+  label_fieldset_state_all_expanded: Alle erweitert

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,6 @@ en:
   label_group_tag_h4: H4
   label_group_tag_fieldset: Fieldset
   label_fieldset_default_state: Fieldset Default State
-  label_fieldset_state_all_expended: All expended
+  label_fieldset_state_all_expanded: All expanded
   label_fieldset_state_all_collapsed: All collapsed
   error_can_not_delete_custom_fields_group: Unable to delete custom fields group

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,6 @@ ja:
   label_group_tag_h4: H4
   label_group_tag_fieldset: フィールドセット
   label_fieldset_default_state: フィールドセットのデフォルト状態
-  label_fieldset_state_all_expended: 全て展開
+  label_fieldset_state_all_expanded: 全て展開
   label_fieldset_state_all_collapsed: 全て折りたたみ
   error_can_not_delete_custom_fields_group: カスタムフィールドグループを削除できません。

--- a/db/migrate/20250502024924_update_settings_and_user_preferences_expend_to_expand.rb
+++ b/db/migrate/20250502024924_update_settings_and_user_preferences_expend_to_expand.rb
@@ -1,0 +1,34 @@
+class UpdateSettingsAndUserPreferencesExpendToExpand < ActiveRecord::Migration[5.2]
+  def up
+    plugin_setting = Setting.where(name: 'plugin_redmine_custom_fields_groups')
+                            .where("value LIKE '%fieldset_default_state: all_expended%'")
+                            &.first
+    if plugin_setting.present?
+      value = plugin_setting.value
+      value[:fieldset_default_state] = 'all_expanded'
+      plugin_setting.value = value
+      plugin_setting.save
+    end
+    user_prefs = UserPreference.where("others LIKE '%:fieldset_default_state: all_expended%'")
+    user_prefs.each do |user_pref|
+      user_pref.others[:fieldset_default_state] = 'all_expanded'
+      user_pref.save
+    end
+  end
+  def down
+    plugin_setting = Setting.where(name: 'plugin_redmine_custom_fields_groups')
+                            .where("value LIKE '%fieldset_default_state: all_expanded%'")
+                            &.first
+    if plugin_setting.present?
+      value = plugin_setting.value
+      value[:fieldset_default_state] = 'all_expended'
+      plugin_setting.value = value
+      plugin_setting.save
+    end
+    user_prefs = UserPreference.where("others LIKE '%:fieldset_default_state: all_expanded%'")
+    user_prefs.each do |user_pref|
+      user_pref.others[:fieldset_default_state] = 'all_expended'
+      user_pref.save
+    end
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -14,7 +14,7 @@ Redmine::Plugin.register :redmine_custom_fields_groups do
   settings partial: 'settings/redmine_custom_fields_groups',
     default: {
       'custom_fields_group_tag' => 'h4',
-      'fieldset_default_state' => 'all_expended'
+      'fieldset_default_state' => 'all_expanded'
     }
 
   menu :admin_menu,

--- a/init.rb
+++ b/init.rb
@@ -7,9 +7,9 @@ Redmine::Plugin.register :redmine_custom_fields_groups do
   author_url 'https://github.com/georepublic'
   url 'https://github.com/gtt-project/redmine_custom_fields_groups'
   description 'This is a plugin for grouping custom fields'
-  version '2.0.0'
+  version '2.1.0'
 
-  requires_redmine :version_or_higher => '5.0.0'
+  requires_redmine :version_or_higher => '5.1.0'
 
   settings partial: 'settings/redmine_custom_fields_groups',
     default: {

--- a/lib/redmine_custom_fields_groups/options.rb
+++ b/lib/redmine_custom_fields_groups/options.rb
@@ -10,7 +10,7 @@ module RedmineCustomFieldsGroups
     end
     def self.fieldset_states
       [
-        [l(:label_fieldset_state_all_expended), "all_expended"],
+        [l(:label_fieldset_state_all_expanded), "all_expanded"],
         [l(:label_fieldset_state_all_collapsed), "all_collapsed"],
       ]
     end

--- a/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
+++ b/lib/redmine_custom_fields_groups/patches/issues_helper_patch.rb
@@ -33,7 +33,7 @@ module RedmineCustomFieldsGroups
             end
             fieldset_default_state = User.current.pref.fieldset_default_state
             if fieldset_default_state.blank?
-              fieldset_default_state = Setting.plugin_redmine_custom_fields_groups['fieldset_default_state'] || 'all_expended'
+              fieldset_default_state = Setting.plugin_redmine_custom_fields_groups['fieldset_default_state'] || 'all_expanded'
             end
 
             s = ''.html_safe

--- a/test/integration/layout_test.rb
+++ b/test/integration/layout_test.rb
@@ -133,10 +133,10 @@ class LayoutTest < Redmine::IntegrationTest
     end
   end
 
-  test 'should show custom fields groups with fieldset tag all expended in issue from plugin setting' do
+  test 'should show custom fields groups with fieldset tag all expanded in issue from plugin setting' do
     Setting.plugin_redmine_custom_fields_groups = {
       'custom_fields_group_tag' => 'fieldset',
-      'fieldset_default_state' => 'all_expended'
+      'fieldset_default_state' => 'all_expanded'
     }
 
     log_user('dlopper', 'foo')
@@ -199,7 +199,7 @@ class LayoutTest < Redmine::IntegrationTest
     }
 
     @user.pref.others[:custom_fields_group_tag] = 'fieldset'
-    @user.pref.others[:fieldset_default_state] = 'all_expended'
+    @user.pref.others[:fieldset_default_state] = 'all_expanded'
     @user.pref.save!
 
     log_user('dlopper', 'foo')

--- a/test/system/fieldset_test.rb
+++ b/test/system/fieldset_test.rb
@@ -19,10 +19,10 @@ class FieldsetTest < ApplicationSystemTestCase
     Setting.clear_cache
   end
 
-  test 'click group title should collapse/expand fieldset with default state all_expended' do
+  test 'click group title should collapse/expand fieldset with default state all_expanded' do
     Setting.plugin_redmine_custom_fields_groups = {
       'custom_fields_group_tag' => 'fieldset',
-      'fieldset_default_state' => 'all_expended'
+      'fieldset_default_state' => 'all_expanded'
     }
 
     log_user('dlopper', 'foo')


### PR DESCRIPTION
Fixes #29

Not sure if this can be updated like this or requires a database migration for existing installations as the setting value seems to be stored with the wrong spelling also in the database.
