### PR TITLE
Fix 'LoadError: cannot load such file -- blankslate' in CI redmine:4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,16 @@ jobs:
         with:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
 
+      - name: Adjust gems
+        working-directory: redmine
+        run: |
+          touch Gemfile.local
+          # https://www.redmine.org/issues/40802
+          if grep -q "require 'blankslate'" lib/redmine/views/builders/structure.rb
+          then
+            echo 'gem "blankslate"' >> Gemfile.local
+          fi
+
       - name: Install Ruby dependencies
         working-directory: redmine
         run: |


### PR DESCRIPTION
Fixes #33.

Changes proposed in this pull request:
- Fix `LoadError: cannot load such file -- blankslate` in CI redmine:4.2

@gtt-project/maintainer
