### PR TITLE
Fix 'Create and add another' button redirect path issue

### DIFF
--- a/app/controllers/custom_fields_groups_controller.rb
+++ b/app/controllers/custom_fields_groups_controller.rb
@@ -17,7 +17,11 @@ class CustomFieldsGroupsController < ApplicationController
     @custom_fields_group.safe_attributes = custom_fields_group_params
     if @custom_fields_group.save
       flash[:notice] = l(:notice_successful_create)
-      redirect_to custom_fields_groups_path
+      if params[:continue]
+        redirect_to new_custom_fields_group_path
+      else
+        redirect_to custom_fields_groups_path
+      end
     else
       render :action => 'new'
     end

--- a/test/functional/custom_fields_groups_controller_test.rb
+++ b/test/functional/custom_fields_groups_controller_test.rb
@@ -39,7 +39,7 @@ class CustomFieldsGroupsControllerTest < ActionController::TestCase
     assert_select 'input[type=checkbox][name=?][value=?]', 'custom_fields_group[custom_field_ids][]', '9'
   end
 
-  test 'should create custom fields gruop' do
+  test 'should create custom fields group' do
     assert_difference 'CustomFieldsGroup.count' do
       post :create, :params => {
         :custom_fields_group => {
@@ -55,7 +55,24 @@ class CustomFieldsGroupsControllerTest < ActionController::TestCase
     assert_equal 4, custom_fields_group.position
   end
 
-  test 'should not create custom fields gruop without name' do
+  test 'should create custom fields group with continue params' do
+    assert_difference 'CustomFieldsGroup.count' do
+      post :create, :params => {
+        :custom_fields_group => {
+          :name => 'Group 4',
+          :custom_field_ids => [9]
+        },
+        :continue => 'Create and add another'
+      }
+    end
+    assert_redirected_to '/custom_fields_groups/new'
+
+    assert custom_fields_group = CustomFieldsGroup.find_by_name('Group 4')
+    assert_equal [9], custom_fields_group.custom_field_ids
+    assert_equal 4, custom_fields_group.position
+  end
+
+  test 'should not create custom fields group without name' do
     post :create, :params => {
       :custom_fields_group => {
         :name => '',


### PR DESCRIPTION
Fixes #37.

Changes proposed in this pull request:
- Fix 'Create and add another' button redirect path issue

@gtt-project/maintainer
